### PR TITLE
Make logfile location consistent for FreeBSD instructions.

### DIFF
--- a/fbsd-relays-adv.html
+++ b/fbsd-relays-adv.html
@@ -146,7 +146,7 @@ affic, FreeBSD likely doesn&#8217;t need that much tweaking.</p>
 
 <p>Tor data, including private key, statistics and Hidden Services: <em>/var/db/tor</em></p>
 
-<p>Tor log file: <em>/var/log/tor</em></p>
+<p>Tor log file: <em>/var/log/tor.log</em></p>
 
 <h3 id="startingrestartingandstoppingtor">Starting, Restarting and Stopping Tor</h3>
 

--- a/fbsd-relays-adv.md
+++ b/fbsd-relays-adv.md
@@ -122,7 +122,7 @@ Tor executible: */usr/local/etc/rc.d/tor*
 
 Tor data, including private key, statistics and Hidden Services: */var/db/tor*
 
-Tor log file: */var/log/tor*
+Tor log file: */var/log/tor.log*
 
 ###Starting, Restarting and Stopping Tor###
 

--- a/fbsd-relays.html
+++ b/fbsd-relays.html
@@ -97,7 +97,7 @@ will create an operational relay.</p>
 <p>Create the appropriate log file with the correct permissions:</p>
 
 <blockquote>
-<p>% touch /var/log tor &amp;&amp; chown _tor:_tor /var/log/tor &amp;&amp; chmod 600 /var/log/tor</p>
+<p>% touch /var/log/tor.log &amp;&amp; chown _tor:_tor /var/log/tor.log &amp;&amp; chmod 600 /var/log/tor.log</p>
 </blockquote>
 
 <p>Add &#8220;tor_enable=YES&#8221; in the /etc/rc.conf file</p>

--- a/fbsd-relays.md
+++ b/fbsd-relays.md
@@ -77,7 +77,7 @@ Edit */usr/local/etc/tor/torrc* appropriately. The torrc file is well-commented 
 
 Create the appropriate log file with the correct permissions:
 
->%  touch /var/log tor && chown _tor:_tor /var/log/tor && chmod 600 /var/log/tor
+>%  touch /var/log/tor.log && chown _tor:_tor /var/log/tor.log && chmod 600 /var/log/tor.log
 
 Add "tor_enable=YES" in the /etc/rc.conf file
 

--- a/fbsd-relays_dev.html
+++ b/fbsd-relays_dev.html
@@ -102,7 +102,7 @@
 </ol>
 
 <blockquote>
-<p>% touch /var/log tor &amp;&amp; chown _tor:_tor /var/log/tor &amp;&amp; chmod 600 /var/log/tor</p>
+<p>% touch /var/log/tor.log &amp;&amp; chown _tor:_tor /var/log/tor.log &amp;&amp; chmod 600 /var/log/tor.log</p>
 </blockquote>
 
 <ol>
@@ -136,7 +136,7 @@
 </ol>
 
 <blockquote>
-<p>% tail -f /var/log/tor</p>
+<p>% tail -f /var/log/tor.log</p>
 </blockquote>
 
 <ol>
@@ -283,7 +283,7 @@ md(4)</p>
 <p>/etc/rc.conf: tor_enable=&#8220;YES&#8221;</p>
 </blockquote>
 
-<p>/var/log/tor</p>
+<p>/var/log/tor.log</p>
 
 <p>chown _tor:_tor</p>
 
@@ -297,7 +297,7 @@ md(4)</p>
 
 <p>Tor data, including private key, statistics and Hidden Services: <em>/var/db/tor</em></p>
 
-<p>Tor log file: <em>/var/log/tor</em></p>
+<p>Tor log file: <em>/var/log/tor.log</em></p>
 
 <h2 id="startingrestartingandstoppingtor">Starting, Restarting and Stopping Tor</h2>
 

--- a/fbsd-relays_dev.md
+++ b/fbsd-relays_dev.md
@@ -74,7 +74,7 @@ or
 
 6. Create the appropriate log file with the correct permission:
 
->%  touch /var/log tor && chown _tor:_tor /var/log/tor && chmod 600 /var/log/tor
+>%  touch /var/log/tor.log && chown _tor:_tor /var/log/tor.log && chmod 600 /var/log/tor.log
 
 7. Add "tor_enable=YES" in the /etc/rc.conf file
 
@@ -92,7 +92,7 @@ or
 
 10. Watch the log to make sure Tor starts correctly:
 
->% tail -f /var/log/tor
+>% tail -f /var/log/tor.log
 
 11. Reboot to confirm that Tor starts correctly.
 
@@ -210,7 +210,7 @@ Currently, the preferred method for installing FreeBSD applications is the ports
 
 >/etc/rc.conf: tor_enable="YES"
 
-/var/log/tor
+/var/log/tor.log
 
 chown _tor:_tor
 
@@ -224,7 +224,7 @@ Tor executible: */usr/local/etc/rc.d/tor*
 
 Tor data, including private key, statistics and Hidden Services: */var/db/tor*
 
-Tor log file: */var/log/tor*
+Tor log file: */var/log/tor.log*
 
 ## Starting, Restarting and Stopping Tor ##
 


### PR DESCRIPTION
Seems like there's some confusion between the various locations of the logfile noted in the FreeBSD instructions on the site and between the sample torrc file.

Making these changes seems to bring the site into consistency with the torrc, but you may want to do it a different way, I'm not sure.
