### PR TITLE
Reporting an issue... in a bit of a weird way...

### DIFF
--- a/fbsd-relays.md
+++ b/fbsd-relays.md
@@ -59,7 +59,7 @@ Install FreeBSD 10 and update to most recent -STABLE version
 
 Populate and/or update the ports tree under */usr/ports*
 
->% svnlite update /usr/ports
+>% svnlite update /usr/ports # didn't work for me
 
 Install either the stable or development version of Tor from the ports tree. The -devel or alpha version of Tor is likely the better choice.
 


### PR DESCRIPTION
Sorry, not really sure how to best report this issue... when I hit the command on the indicated line I get:

    root@TOR2:~ # svnlite update /usr/ports
    Skipped '/usr/ports'
    Summary of conflicts:
      Skipped paths: 1

This is:

    root@TOR2:~ # uname -a
    FreeBSD TOR2 10.3-STABLE FreeBSD 10.3-STABLE #0 r295946+21897e6695f(HEAD): Thu May 25 17:14:15 UTC 2017     root@gauntlet:/freenas-9.10-releng/_BE/objs/freenas-9.10-releng/_BE/os/sys/FreeNAS.amd64  amd64