### PR TITLE
Use sysrc to edit rc.conf instead of echo

### DIFF
--- a/fbsd-relays.html
+++ b/fbsd-relays.html
@@ -103,7 +103,7 @@ will create an operational relay.</p>
 <p>Add &#8220;tor_enable=YES&#8221; in the /etc/rc.conf file</p>
 
 <blockquote>
-<p>% echo &#8220;tor_enable=YES&#8221; &gt;&gt;/etc/rc.conf</p>
+<p>% sysrc tor_enable=YES</p>
 </blockquote>
 
 <p>Enable random IP ID numbers, and make it permanent by adding to /etc/sysctl.conf as per the post-install message:</p>


### PR DESCRIPTION
Using sysrc is the recommended way to edit rc.conf rather than echoing commands.